### PR TITLE
feat: add opt-in Pinecone retrieval practice

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,9 +2,15 @@
 GROQ_API_KEY=your_groq_key_here
 COHERE_API_KEY=your_cohere_key_here
 
-# Vector DB
+# Vector DB (Qdrant remains the default local backend)
+VECTOR_SEARCH_BACKEND=qdrant
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
+
+# Optional Pinecone backend
+PINECONE_API_KEY=
+PINECONE_INDEX_NAME=trojanchat
+PINECONE_NAMESPACE=trojanchat
 
 # Inference Cache
 REDIS_URL=redis://localhost:6379

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   <img src="https://img.shields.io/badge/Streamlit-frontend-FF4B4B?logo=streamlit&logoColor=white" alt="Streamlit">
   <img src="https://img.shields.io/badge/Docker-non--root-2496ED?logo=docker&logoColor=white" alt="Docker">
   <img src="https://img.shields.io/badge/SBOM-CycloneDX-2D9CDB" alt="CycloneDX SBOM">
+  <img src="https://img.shields.io/badge/Pinecone-Optional%20Semantic%20Search-00A98F?logo=pinecone&logoColor=white" alt="Pinecone optional semantic search">
 </p>
 
 <p align="center">
@@ -94,6 +95,20 @@ The intended use, excluded use, data/credential handling, model or algorithm lim
 **What should be completed next?**  
 Use the linked production-readiness issue for this repository as the checklist. Resolve missing tests, deployment instructions, observability, supply-chain controls, and release evidence before attaching a production claim.
 
+
+## Optional Pinecone semantic search
+
+TrojanChat keeps Qdrant as the default local vector backend and provides an opt-in Pinecone adapter for hosted retrieval.
+
+```bash
+python -m pip install -r requirements-pinecone.txt
+export VECTOR_SEARCH_BACKEND=pinecone
+export PINECONE_API_KEY=***
+export PINECONE_INDEX_NAME=trojanchat
+export PINECONE_NAMESPACE=trojanchat
+```
+
+Pinecone quality and operations must be benchmarked independently from the existing bounded in-process storage benchmark: record embedding model, corpus revision, top-k, recall@k, p95/p99 latency, error rate, and cost. Keep credentials in deployment secrets and retain Qdrant/local fallback for offline tests.
 
 ## Engineering evidence
 

--- a/ai/retrieval/pinecone_search.py
+++ b/ai/retrieval/pinecone_search.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from ai.embeddings.cohere_embedder import CohereEmbedder
+
+
+class PineconeSearch:
+    """Pinecone alternative to the existing Qdrant semantic-search path."""
+
+    def __init__(self, index_name: str | None = None):
+        api_key = os.getenv("PINECONE_API_KEY", "").strip()
+        self.index_name = (
+            index_name or os.getenv("PINECONE_INDEX_NAME", "trojanchat")
+        ).strip()
+        self.namespace = os.getenv("PINECONE_NAMESPACE", "trojanchat").strip()
+
+        if not api_key:
+            raise RuntimeError(
+                "PINECONE_API_KEY is required when VECTOR_SEARCH_BACKEND=pinecone."
+            )
+        if not self.index_name or not self.namespace:
+            raise RuntimeError("PINECONE_INDEX_NAME and PINECONE_NAMESPACE are required.")
+
+        from pinecone import Pinecone
+
+        self.index = Pinecone(api_key=api_key).Index(self.index_name)
+        self.embedder = CohereEmbedder()
+
+    def search(
+        self,
+        query: str,
+        top_k: int = 5,
+        filter_condition: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        vector = self.embedder.embed_text(query)
+        response = self.index.query(
+            vector=vector,
+            top_k=top_k,
+            include_metadata=True,
+            namespace=self.namespace,
+            filter=filter_condition,
+        )
+        return [
+            {
+                "id": match.id,
+                "score": match.score,
+                "payload": match.metadata or {},
+            }
+            for match in response.matches
+        ]

--- a/requirements-pinecone.txt
+++ b/requirements-pinecone.txt
@@ -1,0 +1,2 @@
+# Optional hosted semantic-search backend.
+pinecone>=6.0.0


### PR DESCRIPTION
## Summary

Implements the Pinecone and portfolio engineering practices from [SentinelAI issue #13](https://github.com/CoreyLeath-code/SentinelAI/issues/13) for **TrojanChat**.

- preserves the existing local/offline vector backend as the default
- adds an opt-in Pinecone adapter with environment-only secrets
- adds Pinecone configuration and optional dependency documentation
- adds a linked Pinecone badge to the README
- documents hosted retrieval benchmark requirements separately from local measurements
- keeps production and domain claims explicitly bounded

## Validation

The repository's existing CI, tests, security scans, and benchmark workflows should validate the change. Pinecone network calls are not required for default CI.

Refs CoreyLeath-code/SentinelAI#13