### PR TITLE
fix: bound TrojanChat WebSocket chat frames

### DIFF
--- a/backend/routes/ws_routes.py
+++ b/backend/routes/ws_routes.py
@@ -1,8 +1,12 @@
 import asyncio
-from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from typing import List
 
+from fastapi import APIRouter, WebSocket, WebSocketDisconnect
+
 router = APIRouter()
+
+# Keep WebSocket payloads aligned with the HTTP chat endpoint's 2,000-character limit.
+MAX_WEBSOCKET_MESSAGE_SIZE = 2_000
 
 
 class ConnectionManager:
@@ -43,6 +47,11 @@ async def websocket_chat_endpoint(websocket: WebSocket):
     try:
         while True:
             data = await websocket.receive_text()
+            if len(data) > MAX_WEBSOCKET_MESSAGE_SIZE:
+                await websocket.close(code=1009, reason="Message too large")
+                break
             await manager.broadcast(data)
     except WebSocketDisconnect:
+        pass
+    finally:
         await manager.disconnect(websocket)

--- a/tests/test_backend_hardening.py
+++ b/tests/test_backend_hardening.py
@@ -5,6 +5,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 from backend.api import app
+from backend.routes import ws_routes
 from backend.routes.ws_routes import ConnectionManager
 from backend.services.chat_service import ChatService
 from httpx import ASGITransport, AsyncClient
@@ -73,3 +74,33 @@ async def test_connection_manager_connect_and_disconnect() -> None:
     await manager.disconnect(websocket)
     assert websocket not in manager.active_connections
     await asyncio.wait_for(manager.disconnect(websocket), timeout=1)
+
+
+@pytest.mark.asyncio
+async def test_websocket_rejects_oversized_messages_and_disconnects(monkeypatch) -> None:
+    manager = ConnectionManager()
+    monkeypatch.setattr(ws_routes, "manager", manager)
+    websocket = AsyncMock()
+    websocket.receive_text.return_value = "x" * (
+        ws_routes.MAX_WEBSOCKET_MESSAGE_SIZE + 1
+    )
+    manager.broadcast = AsyncMock()
+
+    await ws_routes.websocket_chat_endpoint(websocket)
+
+    websocket.close.assert_awaited_once_with(code=1009, reason="Message too large")
+    manager.broadcast.assert_not_awaited()
+    assert websocket not in manager.active_connections
+
+
+@pytest.mark.asyncio
+async def test_websocket_disconnects_after_unexpected_receive_error(monkeypatch) -> None:
+    manager = ConnectionManager()
+    monkeypatch.setattr(ws_routes, "manager", manager)
+    websocket = AsyncMock()
+    websocket.receive_text.side_effect = RuntimeError("receive failed")
+
+    with pytest.raises(RuntimeError, match="receive failed"):
+        await ws_routes.websocket_chat_endpoint(websocket)
+
+    assert websocket not in manager.active_connections


### PR DESCRIPTION
## Summary

Bounds TrojanChat WebSocket chat frames to 2,000 characters and guarantees removal of connected clients when the receive loop exits unexpectedly.

## Problem

The HTTP chat endpoint rejects content above 2,000 characters, but `/ws/chat` previously accepted and broadcast unbounded text frames. A single large frame could therefore consume unnecessary memory and bandwidth across every connected client. In addition, non-disconnect receive errors could leave a client registered.

## Root cause

The WebSocket endpoint passed every received frame directly to the broadcast loop and only removed connections inside the `WebSocketDisconnect` handler.

## Changes

- Add a 2,000-character WebSocket frame limit aligned with the HTTP endpoint.
- Close oversized frames with WebSocket close code 1009 (`Message too large`) without broadcasting them.
- Move connection removal to a `finally` block so it runs on all exit paths.
- Add async regression tests for oversized-frame rejection and unexpected receive-error cleanup.

## Engineering rationale

Reusing the existing HTTP payload limit keeps the two public chat transports consistent without introducing a new configuration surface. Code 1009 is the standard close code for a message that exceeds an endpoint's acceptable size. A `finally` block is the smallest reliable lifecycle boundary for connection cleanup.

## Validation

- `C:\Users\corey\.cache\codex-runtimes\codex-primary-runtime\dependencies\python\python.exe -m pytest -q tests/test_ws_routes.py`
  - Result: `2 passed in 0.30s`

The repository contains Windows-invalid tracked paths, so a full checkout could not be materialized in this environment. The focused test copied the changed WebSocket module and its regression tests into an isolated harness with FastAPI and pytest installed; no production dependencies or external services were contacted.

## Risk

Low. WebSocket messages longer than 2,000 characters are now rejected instead of broadcast. Valid frames continue through the existing broadcast path.

## Rollback

Revert commits `6a1b35d` and `f9f772a` (or revert this PR) to restore the previous WebSocket behavior.

## Follow-up work

- Exercise the complete repository test suite in an environment that can checkout its Windows-incompatible tracked paths.
- Review whether WebSocket fan-out needs per-client send timeouts or backpressure as concurrent-client usage grows.

Fixes #29

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * WebSocket chat messages exceeding 2,000 characters are now rejected and the connection is closed with an appropriate “message too large” status.
  * Oversized messages are no longer broadcast to connected clients.
  * Connections are properly cleaned up when receiving messages fails.

* **Tests**
  * Added coverage for oversized messages and connection cleanup during receive errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->